### PR TITLE
adding loadbalancer.yaml and refining docs and deployment.yaml

### DIFF
--- a/devops/gke-config/loadbalancer.yaml
+++ b/devops/gke-config/loadbalancer.yaml
@@ -12,44 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: devops-handson-deployment
-spec:
-  selector:
-    matchLabels:
-      app: devops-handson
-  replicas: 2
-  template:
-    metadata:
-      labels:
-        app: devops-handson
-    spec:
-      containers:
-      - name: myapp
-        image: gcr.io/FIXME/devops-handson:v1
-        ports:
-        - containerPort: 8080
----
 apiVersion: v1
 kind: Service
 metadata:
-  name: devops-handson
+  name: devops-handson-loadbalancer
 spec:
-  type: NodePort
+  type: LoadBalancer
   selector:
     app: devops-handson
   ports:
   - protocol: TCP
-    port: 8080
+    port: 80
     targetPort: 8080
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: devops-handson-ingress
-spec:
-  backend:
-    serviceName: devops-handson
-    servicePort: 8080

--- a/devops/tutorial.md
+++ b/devops/tutorial.md
@@ -187,6 +187,25 @@ http://<INGRESS-IP>/
 
 ![BrowserAccessToMainController](https://storage.googleapis.com/devops-handson-for-github/BrowserAccessToMainController.png)
 
+Ingress 以外にも、Loadbalancer を作成して動作確認することができる。※ Ingress の作成に時間を要している場合は試してみましょう。
+
+```bash
+kubectl apply -f gke-config/loadbalancer.yaml
+```
+
+以下のコマンドで Loadbalancer のグローバル IP を確認し、アクセス。
+
+```bash
+kubectl get service/devops-handson-loadbalancer
+```
+```
+NAME                          TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)        AGE
+devops-handson-loadbalancer   LoadBalancer   10.x.x.x      xx.xx.xx.xx    80:30090/TCP   1m
+```
+
+
+
+## Apache Bench で /bench1 へ複数回アクセスをする
 後のステップで確認する Stackdriver Profiler のサンプル数を稼ぐため、Apache Bench を使い複数回、/bench1 へのアクセスを行う。
 Timeout エラーが出た場合は -t の値を増やしてみてください。（Timeout値）
 


### PR DESCRIPTION
deployment.yaml 
- apps/v1 表記に更新
- 使われていない name:app を削除
- https://cloud.google.com/kubernetes-engine/docs/how-to/exposing-apps こちらのサンプルに書き方を寄せた

loadbalancer.yaml
- deployment.yaml で使った deployment を再利用（ハンズオン中で sed を2回する手間などを省くため）