### PR TITLE
Remove cluster version from GKE cluster create command(step)

### DIFF
--- a/appdev/tutorial.md
+++ b/appdev/tutorial.md
@@ -109,7 +109,6 @@ gcloud container clusters create "k8s-appdev-handson"  \
 --scopes "https://www.googleapis.com/auth/cloud-platform" \
 --num-nodes "3" \
 --enable-stackdriver-kubernetes \
---cluster-version "1.14.10-gke.27" \
 --enable-ip-alias \
 --network "projects/$GOOGLE_CLOUD_PROJECT/global/networks/default" \
 --subnetwork "projects/$GOOGLE_CLOUD_PROJECT/regions/asia-northeast1/subnetworks/default" \


### PR DESCRIPTION
The version raises version unsupported error. Now we don't need specific version because workload identity is suppoerted by default version.