### PR TITLE
Fix a bug

### DIFF
--- a/hpc/slurm-lustre-operations/stop-lustre.sh
+++ b/hpc/slurm-lustre-operations/stop-lustre.sh
@@ -3,13 +3,13 @@
 oss=$( gcloud deployment-manager deployments describe lustre --format json \
     | jq -r '.resources[]|select(.type=="compute.v1.instance")|.name' \
     | grep oss)
-for id in "${oss}"; do
+for id in ${oss}; do
     gcloud compute instances stop "${id}" --zone=asia-northeast1-c
 done
 
 mds=$( gcloud deployment-manager deployments describe lustre --format json \
     | jq -r '.resources[]|select(.type=="compute.v1.instance")|.name' \
     | grep mds)
-for id in "${mds}"; do
+for id in ${mds}; do
     gcloud compute instances stop "${id}" --zone=asia-northeast1-c
 done


### PR DESCRIPTION
Remove double quotations for loop variables which cause an error when there are 2+ target VMs found.