### PR TITLE
Fix a bug on HPC hands-on

### DIFF
--- a/hpc/slurm-lustre-operations/start-lustre.sh
+++ b/hpc/slurm-lustre-operations/start-lustre.sh
@@ -3,7 +3,7 @@
 mds=$( gcloud deployment-manager deployments describe lustre --format json \
     | jq -r '.resources[]|select(.type=="compute.v1.instance")|.name' \
     | grep mds)
-for id in "${mds}"; do
+for id in ${mds}; do
     gcloud compute instances start "${id}" --zone=asia-northeast1-c
 done
 
@@ -22,7 +22,7 @@ done
 oss=$( gcloud deployment-manager deployments describe lustre --format json \
     | jq -r '.resources[]|select(.type=="compute.v1.instance")|.name' \
     | grep oss)
-for id in "${oss}"; do
+for id in ${oss}; do
     gcloud compute instances start "${id}" --zone=asia-northeast1-c
 done
 


### PR DESCRIPTION
Fix the same issue as stop-lustre.sh. ( #61 )
Remove double quotations for loop variables which cause an error when there are 2+ target VMs found.