### PR TITLE
Upgrade deployment apiVersion to apps/v1

### DIFF
--- a/fundamental/gke/helloNode/hello-node-deployment.yaml
+++ b/fundamental/gke/helloNode/hello-node-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -6,6 +6,9 @@ metadata:
   name: hello-node
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: hello-node
   template:
     metadata:
       labels:


### PR DESCRIPTION
### What type of PR is this?
Bug fix

### What this PR does / why we need it:

The appVersion `extentions/v1beta1` of Deployment was deprecated in kubernetes v1.16.
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

So it will return the error when users apply the old manifest.
This PR will upgrade the apiVersion of Deployment resource.