### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/appdev/tutorial.md
+++ b/appdev/tutorial.md
@@ -97,7 +97,6 @@ gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT  --member serviceAc
 
 ```bash
 gcloud container clusters create "k8s-appdev-handson"  \
---image-type "COS" \
 --machine-type "n1-standard-2" \
 --enable-stackdriver-kubernetes \
 --enable-ip-alias \


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.