### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/devops/tutorial.md
+++ b/devops/tutorial.md
@@ -258,7 +258,6 @@ docker push asia-northeast1-docker.pkg.dev/$GOOGLE_CLOUD_PROJECT/gcp-getting-sta
 
 ```bash
 gcloud container clusters create "k8s-devops-handson"  \
---image-type "COS" \
 --enable-stackdriver-kubernetes \
 --enable-ip-alias \
 --release-channel stable \


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.