### PR TITLE
[cloudrun2] Fix a gosec warning, 'G402: TLS MinVersion too low.'

### DIFF
--- a/cloudrun2/notification/cmd/client/main.go
+++ b/cloudrun2/notification/cmd/client/main.go
@@ -87,7 +87,8 @@ func makeConnection() (*grpc.ClientConn, error) {
 			log.Fatalf("Could not make cert pool: %v", err)
 		}
 		cred := credentials.NewTLS(&tls.Config{
-			RootCAs: systemRoots,
+			RootCAs:    systemRoots,
+			MinVersion: tls.VersionTLS12,
 		})
 		opts = append(opts, grpc.WithTransportCredentials(cred))
 	}


### PR DESCRIPTION
golangci/golanci-lint でチェックしたところ、gosec の警告があったのでそこだけ修正してみました。