### PR TITLE
Update online boutique to address Log4j vulnerability

### DIFF
--- a/anthos/k8s-manifest/frontend-v1.yaml
+++ b/anthos/k8s-manifest/frontend-v1.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.1
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.2
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/anthos/k8s-manifest/frontend-v2.yaml
+++ b/anthos/k8s-manifest/frontend-v2.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.1
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.2
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/anthos/k8s-manifest/kubernetes-manifests.yaml
+++ b/anthos/k8s-manifest/kubernetes-manifests.yaml
@@ -32,32 +32,32 @@ spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-        - name: server
-          image: gcr.io/google-samples/microservices-demo/emailservice:v0.2.1
-          ports:
-            - containerPort: 8080
-          env:
-            - name: PORT
-              value: "8080"
-            # - name: DISABLE_TRACING
-            #   value: "1"
-            - name: DISABLE_PROFILER
-              value: "1"
-          readinessProbe:
-            periodSeconds: 5
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:8080"]
-          livenessProbe:
-            periodSeconds: 5
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:8080"]
-          resources:
-            requests:
-              cpu: 100m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 128Mi
+      - name: server
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.5
+        ports:
+        - containerPort: 8080
+        env:
+        - name: PORT
+          value: "8080"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        readinessProbe:
+          periodSeconds: 5
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:8080"]
+        livenessProbe:
+          periodSeconds: 5
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:8080"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service
@@ -68,9 +68,9 @@ spec:
   selector:
     app: emailservice
   ports:
-    - name: grpc
-      port: 5000
-      targetPort: 8080
+  - name: grpc
+    port: 5000
+    targetPort: 8080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -88,9 +88,9 @@ spec:
       serviceAccountName: default
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.2.1
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.5
           ports:
-            - containerPort: 5050
+          - containerPort: 5050
           readinessProbe:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:5050"]
@@ -98,26 +98,26 @@ spec:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:5050"]
           env:
-            - name: PORT
-              value: "5050"
-            - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: "productcatalogservice:3550"
-            - name: SHIPPING_SERVICE_ADDR
-              value: "shippingservice:50051"
-            - name: PAYMENT_SERVICE_ADDR
-              value: "paymentservice:50051"
-            - name: EMAIL_SERVICE_ADDR
-              value: "emailservice:5000"
-            - name: CURRENCY_SERVICE_ADDR
-              value: "currencyservice:7000"
-            - name: CART_SERVICE_ADDR
-              value: "cartservice:7070"
-          # - name: DISABLE_STATS
-          #   value: "1"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
+          - name: PORT
+            value: "5050"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: "productcatalogservice:3550"
+          - name: SHIPPING_SERVICE_ADDR
+            value: "shippingservice:50051"
+          - name: PAYMENT_SERVICE_ADDR
+            value: "paymentservice:50051"
+          - name: EMAIL_SERVICE_ADDR
+            value: "emailservice:5000"
+          - name: CURRENCY_SERVICE_ADDR
+            value: "currencyservice:7000"
+          - name: CART_SERVICE_ADDR
+            value: "cartservice:7070"
+          - name: DISABLE_STATS
+            value: "1"
+          - name: DISABLE_TRACING
+            value: "1"
+          - name: DISABLE_PROFILER
+            value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
           resources:
@@ -137,9 +137,9 @@ spec:
   selector:
     app: checkoutservice
   ports:
-    - name: grpc
-      port: 5050
-      targetPort: 5050
+  - name: grpc
+    port: 5050
+    targetPort: 5050
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -154,38 +154,39 @@ spec:
       labels:
         app: recommendationservice
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-        - name: server
-          image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.2.1
-          ports:
-            - containerPort: 8080
-          readinessProbe:
-            periodSeconds: 5
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:8080"]
-          livenessProbe:
-            periodSeconds: 5
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:8080"]
-          env:
-            - name: PORT
-              value: "8080"
-            - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: "productcatalogservice:3550"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
-          # - name: DISABLE_DEBUGGER
-          #   value: "1"
-          resources:
-            requests:
-              cpu: 100m
-              memory: 220Mi
-            limits:
-              cpu: 200m
-              memory: 450Mi
+      - name: server
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.5
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          periodSeconds: 5
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:8080"]
+        livenessProbe:
+          periodSeconds: 5
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:8080"]
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 220Mi
+          limits:
+            cpu: 200m
+            memory: 450Mi
 ---
 apiVersion: v1
 kind: Service
@@ -196,9 +197,9 @@ spec:
   selector:
     app: recommendationservice
   ports:
-    - name: grpc
-      port: 8080
-      targetPort: 8080
+  - name: grpc
+    port: 8080
+    targetPort: 8080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -218,50 +219,54 @@ spec:
       serviceAccountName: default
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.1
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.5
           ports:
-            - containerPort: 8080
+          - containerPort: 8080
           readinessProbe:
             initialDelaySeconds: 10
             httpGet:
               path: "/_healthz"
               port: 8080
               httpHeaders:
-                - name: "Cookie"
-                  value: "shop_session-id=x-readiness-probe"
+              - name: "Cookie"
+                value: "shop_session-id=x-readiness-probe"
           livenessProbe:
             initialDelaySeconds: 10
             httpGet:
               path: "/_healthz"
               port: 8080
               httpHeaders:
-                - name: "Cookie"
-                  value: "shop_session-id=x-liveness-probe"
+              - name: "Cookie"
+                value: "shop_session-id=x-liveness-probe"
           env:
-            - name: PORT
-              value: "8080"
-            - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: "productcatalogservice:3550"
-            - name: CURRENCY_SERVICE_ADDR
-              value: "currencyservice:7000"
-            - name: CART_SERVICE_ADDR
-              value: "cartservice:7070"
-            - name: RECOMMENDATION_SERVICE_ADDR
-              value: "recommendationservice:8080"
-            - name: SHIPPING_SERVICE_ADDR
-              value: "shippingservice:50051"
-            - name: CHECKOUT_SERVICE_ADDR
-              value: "checkoutservice:5050"
-            - name: AD_SERVICE_ADDR
-              value: "adservice:9555"
-            - name: ENV_PLATFORM
-              value: "gcp"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
+          - name: PORT
+            value: "8080"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: "productcatalogservice:3550"
+          - name: CURRENCY_SERVICE_ADDR
+            value: "currencyservice:7000"
+          - name: CART_SERVICE_ADDR
+            value: "cartservice:7070"
+          - name: RECOMMENDATION_SERVICE_ADDR
+            value: "recommendationservice:8080"
+          - name: SHIPPING_SERVICE_ADDR
+            value: "shippingservice:50051"
+          - name: CHECKOUT_SERVICE_ADDR
+            value: "checkoutservice:5050"
+          - name: AD_SERVICE_ADDR
+            value: "adservice:9555"
+          # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
+          # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp 
+          # - name: ENV_PLATFORM 
+          #   value: "aws"
+          - name: DISABLE_TRACING
+            value: "1"
+          - name: DISABLE_PROFILER
+            value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
+          # - name: CYMBAL_BRANDING
+          #   value: "true"
           resources:
             requests:
               cpu: 100m
@@ -279,9 +284,9 @@ spec:
   selector:
     app: frontend
   ports:
-    - name: http
-      port: 80
-      targetPort: 8080
+  - name: http
+    port: 80
+    targetPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -292,9 +297,9 @@ spec:
   selector:
     app: frontend
   ports:
-    - name: http
-      port: 80
-      targetPort: 8080
+  - name: http
+    port: 80
+    targetPort: 8080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -312,26 +317,32 @@ spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-        - name: server
-          image: gcr.io/google-samples/microservices-demo/paymentservice:v0.2.1
-          ports:
-            - containerPort: 50051
-          env:
-            - name: PORT
-              value: "50051"
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          resources:
-            requests:
-              cpu: 100m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 128Mi
+      - name: server
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.5
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
+        readinessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+        livenessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service
@@ -342,9 +353,9 @@ spec:
   selector:
     app: paymentservice
   ports:
-    - name: grpc
-      port: 50051
-      targetPort: 50051
+  - name: grpc
+    port: 50051
+    targetPort: 50051
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -362,34 +373,34 @@ spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-        - name: server
-          image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.2.1
-          ports:
-            - containerPort: 3550
-          env:
-            - name: PORT
-              value: "3550"
-          # - name: DISABLE_STATS
-          #   value: "1"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
-          # - name: JAEGER_SERVICE_ADDR
-          #   value: "jaeger-collector:14268"
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:3550"]
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:3550"]
-          resources:
-            requests:
-              cpu: 100m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 128Mi
+      - name: server
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.5
+        ports:
+        - containerPort: 3550
+        env:
+        - name: PORT
+          value: "3550"
+        - name: DISABLE_STATS
+          value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        # - name: JAEGER_SERVICE_ADDR
+        #   value: "jaeger-collector:14268"
+        readinessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:3550"]
+        livenessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:3550"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service
@@ -400,9 +411,9 @@ spec:
   selector:
     app: productcatalogservice
   ports:
-    - name: grpc
-      port: 3550
-      targetPort: 3550
+  - name: grpc
+    port: 3550
+    targetPort: 3550
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -420,35 +431,29 @@ spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-        - name: server
-          image: gcr.io/google-samples/microservices-demo/cartservice:v0.2.1
-          ports:
-            - containerPort: 7070
-          env:
-            - name: REDIS_ADDR
-              value: "redis-cart:6379"
-            - name: PORT
-              value: "7070"
-            - name: LISTEN_ADDR
-              value: "0.0.0.0"
-          resources:
-            requests:
-              cpu: 200m
-              memory: 64Mi
-            limits:
-              cpu: 300m
-              memory: 128Mi
-          readinessProbe:
-            initialDelaySeconds: 15
-            exec:
-              command:
-                ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
-          livenessProbe:
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            exec:
-              command:
-                ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
+      - name: server
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.5
+        ports:
+        - containerPort: 7070
+        env:
+        - name: REDIS_ADDR
+          value: "redis-cart:6379"
+        resources:
+          requests:
+            cpu: 200m
+            memory: 64Mi
+          limits:
+            cpu: 300m
+            memory: 128Mi
+        readinessProbe:
+          initialDelaySeconds: 15
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
 ---
 apiVersion: v1
 kind: Service
@@ -459,9 +464,9 @@ spec:
   selector:
     app: cartservice
   ports:
-    - name: grpc
-      port: 7070
-      targetPort: 7070
+  - name: grpc
+    port: 7070
+    targetPort: 7070
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -482,21 +487,37 @@ spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
+      initContainers:
+      - command:
+        - /bin/sh
+        - -exc
+        - |
+          echo "Init container pinging frontend: ${FRONTEND_ADDR}..."
+          STATUSCODE=$(wget --server-response http://${FRONTEND_ADDR} 2>&1 | awk '/^  HTTP/{print $2}')
+          if test $STATUSCODE -ne 200; then
+              echo "Error: Could not reach frontend - Status code: ${STATUSCODE}"
+              exit 1
+          fi
+        name: frontend-check
+        image: busybox:latest
+        env:
+        - name: FRONTEND_ADDR
+          value: "frontend:80"
       containers:
-        - name: main
-          image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.2.1
-          env:
-            - name: FRONTEND_ADDR
-              value: "frontend:80"
-            - name: USERS
-              value: "10"
-          resources:
-            requests:
-              cpu: 300m
-              memory: 256Mi
-            limits:
-              cpu: 500m
-              memory: 512Mi
+      - name: main
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.3.5
+        env:
+        - name: FRONTEND_ADDR
+          value: "frontend:80"
+        - name: USERS
+          value: "10"
+        resources:
+          requests:
+            cpu: 300m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -514,33 +535,33 @@ spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-        - name: server
-          image: gcr.io/google-samples/microservices-demo/currencyservice:v0.2.1
-          ports:
-            - name: grpc
-              containerPort: 7000
-          env:
-            - name: PORT
-              value: "7000"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
-          # - name: DISABLE_DEBUGGER
-          #   value: "1"
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:7000"]
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:7000"]
-          resources:
-            requests:
-              cpu: 100m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 128Mi
+      - name: server
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.5
+        ports:
+        - name: grpc
+          containerPort: 7000
+        env:
+        - name: PORT
+          value: "7000"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
+        readinessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:7000"]
+        livenessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:7000"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service
@@ -551,9 +572,9 @@ spec:
   selector:
     app: currencyservice
   ports:
-    - name: grpc
-      port: 7000
-      targetPort: 7000
+  - name: grpc
+    port: 7000
+    targetPort: 7000
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -568,36 +589,37 @@ spec:
       labels:
         app: shippingservice
     spec:
+      serviceAccountName: default
       containers:
-        - name: server
-          image: gcr.io/google-samples/microservices-demo/shippingservice:v0.2.1
-          ports:
-            - containerPort: 50051
-          env:
-            - name: PORT
-              value: "50051"
-          # - name: DISABLE_STATS
-          #   value: "1"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
-          # - name: JAEGER_SERVICE_ADDR
-          #   value: "jaeger-collector:14268"
-          readinessProbe:
-            periodSeconds: 5
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          resources:
-            requests:
-              cpu: 100m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 128Mi
+      - name: server
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.5
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_STATS
+          value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        # - name: JAEGER_SERVICE_ADDR
+        #   value: "jaeger-collector:14268"
+        readinessProbe:
+          periodSeconds: 5
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+        livenessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service
@@ -608,9 +630,9 @@ spec:
   selector:
     app: shippingservice
   ports:
-    - name: grpc
-      port: 50051
-      targetPort: 50051
+  - name: grpc
+    port: 50051
+    targetPort: 50051
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -626,31 +648,31 @@ spec:
         app: redis-cart
     spec:
       containers:
-        - name: redis
-          image: redis:alpine
-          ports:
-            - containerPort: 6379
-          readinessProbe:
-            periodSeconds: 5
-            tcpSocket:
-              port: 6379
-          livenessProbe:
-            periodSeconds: 5
-            tcpSocket:
-              port: 6379
-          volumeMounts:
-            - mountPath: /data
-              name: redis-data
-          resources:
-            limits:
-              memory: 256Mi
-              cpu: 125m
-            requests:
-              cpu: 70m
-              memory: 200Mi
+      - name: redis
+        image: redis:alpine
+        ports:
+        - containerPort: 6379
+        readinessProbe:
+          periodSeconds: 5
+          tcpSocket:
+            port: 6379
+        livenessProbe:
+          periodSeconds: 5
+          tcpSocket:
+            port: 6379
+        volumeMounts:
+        - mountPath: /data
+          name: redis-data
+        resources:
+          limits:
+            memory: 256Mi
+            cpu: 125m
+          requests:
+            cpu: 70m
+            memory: 200Mi
       volumes:
-        - name: redis-data
-          emptyDir: {}
+      - name: redis-data
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service
@@ -661,9 +683,9 @@ spec:
   selector:
     app: redis-cart
   ports:
-    - name: redis
-      port: 6379
-      targetPort: 6379
+  - name: redis
+    port: 6379
+    targetPort: 6379
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -681,36 +703,36 @@ spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-        - name: server
-          image: gcr.io/google-samples/microservices-demo/adservice:v0.2.1
-          ports:
-            - containerPort: 9555
-          env:
-            - name: PORT
-              value: "9555"
-          # - name: DISABLE_STATS
-          #   value: "1"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          #- name: JAEGER_SERVICE_ADDR
-          #  value: "jaeger-collector:14268"
-          resources:
-            requests:
-              cpu: 200m
-              memory: 180Mi
-            limits:
-              cpu: 300m
-              memory: 300Mi
-          readinessProbe:
-            initialDelaySeconds: 20
-            periodSeconds: 15
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:9555"]
-          livenessProbe:
-            initialDelaySeconds: 20
-            periodSeconds: 15
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:9555"]
+      - name: server
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.3.5
+        ports:
+        - containerPort: 9555
+        env:
+        - name: PORT
+          value: "9555"
+        - name: DISABLE_STATS
+          value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        # - name: JAEGER_SERVICE_ADDR
+        #   value: "jaeger-collector:14268"
+        resources:
+          requests:
+            cpu: 200m
+            memory: 180Mi
+          limits:
+            cpu: 300m
+            memory: 300Mi
+        readinessProbe:
+          initialDelaySeconds: 20
+          periodSeconds: 15
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:9555"]
+        livenessProbe:
+          initialDelaySeconds: 20
+          periodSeconds: 15
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:9555"]
 ---
 apiVersion: v1
 kind: Service
@@ -721,8 +743,7 @@ spec:
   selector:
     app: adservice
   ports:
-    - name: grpc
-      port: 9555
-      targetPort: 9555
+  - name: grpc
+    port: 9555
+    targetPort: 9555
 ---
-


### PR DESCRIPTION
- Update online boutique demo application from v0.2.1 to v0.3.5.
- Keep v0.2.2 for frontend (written in Golang) to make hands-on works.